### PR TITLE
Fix FrameBuffer empty segments caused by wrap-around handling

### DIFF
--- a/frame_buffer.go
+++ b/frame_buffer.go
@@ -28,9 +28,18 @@ func (fb *FrameBuffer) AddFramesToBuffer(startFrame uint32, endFrame uint32, dat
 	}
 
 	batchStartIndex := (startFrame * FrameSize) % BufferSize
-	batchEndIndex := (endFrame*FrameSize + FrameSize) % BufferSize // `+FrameSize` because `endFrame*FrameSize` defines where the last frame starts. But what we actually meed os where it ends. i.e. the position of the last byte of the frameBatch
+	batchEndIndex := (endFrame*FrameSize + FrameSize) % BufferSize // `+FrameSize` because `endFrame*FrameSize` defines where the last frame starts. But what we actually need is where it ends. i.e. the position of the last byte of the frameBatch
 
-	if batchEndIndex-batchStartIndex != BatchSize {
+	// Fix: Handle wrap-around case for batch size validation
+	var batchActualSize uint32
+	if batchEndIndex >= batchStartIndex {
+		batchActualSize = batchEndIndex - batchStartIndex
+	} else {
+		// Wrapped around: from start to end of buffer + from start of buffer to end index
+		batchActualSize = (BufferSize - batchStartIndex) + batchEndIndex
+	}
+
+	if batchActualSize != BatchSize {
 		return errors.New("received incorrect batch size")
 	}
 
@@ -42,7 +51,16 @@ func (fb *FrameBuffer) AddFramesToBuffer(startFrame uint32, endFrame uint32, dat
 		return errors.New("framebuffer length is 0")
 	}
 
-	copy(fb.buffer[batchStartIndex:batchEndIndex], data[:])
+	// Fix: Handle wrap-around case for copying data
+	if batchEndIndex >= batchStartIndex {
+		// Normal case: no wrap-around
+		copy(fb.buffer[batchStartIndex:batchEndIndex], data[:])
+	} else {
+		// Wrap-around case: copy in two parts
+		firstPartSize := BufferSize - batchStartIndex
+		copy(fb.buffer[batchStartIndex:], data[:firstPartSize])
+		copy(fb.buffer[:batchEndIndex], data[firstPartSize:])
+	}
 
 	fb.head = max(fb.head, batchEndIndex)
 	log.Println("startFramePosition", batchStartIndex)
@@ -57,10 +75,21 @@ func (fb *FrameBuffer) GetFrames() []byte {
 	if length == 0 {
 		return nil
 	}
+	
+	// Fix: Handle wrap-around case properly
 	if fb.head >= fb.tail {
+		// Normal case: no wrap-around
 		return fb.buffer[fb.tail%BufferSize : fb.head%BufferSize]
+	} else {
+		// Wrap-around case: concatenate two parts
+		// From tail to end of buffer + from start of buffer to head
+		part1 := fb.buffer[fb.tail:]
+		part2 := fb.buffer[:fb.head]
+		result := make([]byte, len(part1)+len(part2))
+		copy(result, part1)
+		copy(result[len(part1):], part2)
+		return result
 	}
-	return fb.buffer[fb.head%BufferSize : fb.tail%BufferSize]
 }
 
 func (fb *FrameBuffer) RemoveSentFramesFromBuffer() {


### PR DESCRIPTION
## Overview
This PR fixes critical bugs in the FrameBuffer implementation that caused empty segments when the circular buffer wraps around.

## Issues Fixed

### 1. Batch Size Validation Failure on Wrap-Around
**Problem:** In the `AddFramesToBuffer` method, the validation `batchEndIndex-batchStartIndex != BatchSize` fails when the buffer wraps around. When wrapping occurs, `batchEndIndex` can be smaller than `batchStartIndex` due to modulo arithmetic, causing an integer underflow and incorrect batch size calculation.

**Fix:** Added proper wrap-around detection and calculation:
```go
var batchActualSize uint32
if batchEndIndex >= batchStartIndex {
    batchActualSize = batchEndIndex - batchStartIndex
} else {
    // Wrapped around: from start to end of buffer + from start of buffer to end index
    batchActualSize = (BufferSize - batchStartIndex) + batchEndIndex
}
```

### 2. Empty Slice Return in GetFrames()
**Problem:** In the `GetFrames()` method, when the buffer wraps around (`head < tail`), the return statement `fb.buffer[fb.head%BufferSize : fb.tail%BufferSize]` returns an empty or invalid slice because `head < tail`, resulting in a backwards slice range.

**Fix:** Properly handle the wrap-around case by concatenating two slices:
```go
if fb.head >= fb.tail {
    // Normal case: no wrap-around
    return fb.buffer[fb.tail%BufferSize : fb.head%BufferSize]
} else {
    // Wrap-around case: concatenate two parts
    part1 := fb.buffer[fb.tail:]
    part2 := fb.buffer[:fb.head]
    result := make([]byte, len(part1)+len(part2))
    copy(result, part1)
    copy(result[len(part1):], part2)
    return result
}
```

### 3. Copy Operation Doesn't Handle Wrap-Around
**Problem:** The copy operation in `AddFramesToBuffer` uses `copy(fb.buffer[batchStartIndex:batchEndIndex], data[:])`, which fails when `batchEndIndex < batchStartIndex` (wrap-around case), resulting in data not being copied correctly or a panic.

**Fix:** Handle wrap-around by splitting the copy operation into two parts:
```go
if batchEndIndex >= batchStartIndex {
    // Normal case: no wrap-around
    copy(fb.buffer[batchStartIndex:batchEndIndex], data[:])
} else {
    // Wrap-around case: copy in two parts
    firstPartSize := BufferSize - batchStartIndex
    copy(fb.buffer[batchStartIndex:], data[:firstPartSize])
    copy(fb.buffer[:batchEndIndex], data[firstPartSize:])
}
```

## Impact
These fixes ensure that the FrameBuffer correctly handles circular buffer wrap-around scenarios, preventing data loss and ensuring continuous frame streaming.